### PR TITLE
Fix: Attempt to remove non existing binary in clean target

### DIFF
--- a/src/examples/compositors/simple-compositor/Makefile
+++ b/src/examples/compositors/simple-compositor/Makefile
@@ -11,4 +11,5 @@ compositor: main.cpp
 	${CC}  main.cpp  ${CFLAGS} ${INCLUDES} ${LIBS} -o simple-compositor 
 
 clean:
-	rm simple-compositor 
+	rm -f simple-compositor
+ 


### PR DESCRIPTION
 made build.sh break. "-f" makes rm not exit with an error code.
